### PR TITLE
Fix: Scrollbar Disabling Issue (#5)

### DIFF
--- a/src/scss/custom/_editor.scss
+++ b/src/scss/custom/_editor.scss
@@ -1,6 +1,6 @@
 // Editor & preview style
 .bs-cheatsheet.modal-open{
-  overflow: auto;
+  overflow: auto !important;
   margin-bottom: $modal-height;
   padding-right: 0 !important;
 }


### PR DESCRIPTION
### Summary
This PR addresses issue #5 where the scrollbar gets disabled when viewing an example on the page. The issue was fixed by modifying the `_editor.scss` file to ensure that the scrollbar remains functional.

### Changes Made
- Added `!important` to the `overflow: auto` property to ensure the scrollbar remains enabled in the `.bs-cheatsheet.modal-open` class and `overflow: hidden` property not get applied.

### Issue Reference
- Issue #5: Scrollbar gets disabled when viewing examples.

### Note
- I encountered a build conflict on my machine, preventing me from compiling the `src` folder into `assets` using `gulp`. The issue might require someone with a functioning build setup to verify the changes.
